### PR TITLE
Fix PNG export and adjust incoming bubble spacing

### DIFF
--- a/components/ChatPreview.tsx
+++ b/components/ChatPreview.tsx
@@ -67,7 +67,7 @@ function Bubble({ m }: { m: ChatMessage }) {
     'shadow-[0_1px_0_rgba(0,0,0,.10)]'
   );
   return (
-    <div className={cn('w-full flex', isMe ? 'justify-end pr-1' : 'justify-start pl-1')}>
+    <div className={cn('w-full flex', isMe ? 'justify-end pr-1' : 'justify-start pl-2')}>
       <div className="max-w-[78%]">
         <div className={cls} style={{ background: bg, color: '#111B21' }}>
           <Tail me={isMe} color={bg} />

--- a/src/lib/exportToPng.ts
+++ b/src/lib/exportToPng.ts
@@ -5,7 +5,16 @@ export async function exportNodeToPNG(node: HTMLElement, scale = 2): Promise<Blo
     backgroundColor: null,
     scale,
     useCORS: true,
-    allowTaint: true
+    allowTaint: true,
   });
-  return new Promise<Blob>((resolve) => canvas.toBlob((b) => resolve(b as Blob), "image/png"));
+
+  const blob = await new Promise<Blob | null>((resolve) =>
+    canvas.toBlob((b) => resolve(b), "image/png")
+  );
+
+  if (blob) return blob;
+
+  const dataUrl = canvas.toDataURL("image/png");
+  const res = await fetch(dataUrl);
+  return res.blob();
 }


### PR DESCRIPTION
## Summary
- ensure PNG export always returns a blob by falling back to data URLs
- add extra left padding so incoming messages aren't flush with preview edge

## Testing
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68a64970726483298ece4490142e63df