### PR TITLE
Fix PNG export opacity causing blank images

### DIFF
--- a/app/page.tsx
+++ b/app/page.tsx
@@ -35,12 +35,16 @@ export default function Page() {
     const node = exportRef.current;
     if (!node) return;
 
+    const prevDisplay = node.style.display;
+    const prevOpacity = node.style.opacity;
     node.style.display = "block";
+    node.style.opacity = "1";
     await new Promise((r) => setTimeout(r, 50));
 
     const blob = await exportNodeToPNG(node, 2);
 
-    node.style.display = "none";
+    node.style.display = prevDisplay;
+    node.style.opacity = prevOpacity;
 
     const url = URL.createObjectURL(blob);
     const a = document.createElement("a");


### PR DESCRIPTION
## Summary
- ensure hidden export surface is visible during PNG capture

## Testing
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68a64ce8d81c8329ba4afd283c15b3cc