### PR TITLE
Fix download PNG mismatch with live preview

### DIFF
--- a/app/layout.tsx
+++ b/app/layout.tsx
@@ -2,7 +2,7 @@ import './globals.css';
 
 export const metadata = {
   title: "Fake WhatsApp Chat Generator",
-  description: "Create realistic fake WhatsApp chats. Free, no signup."
+  description: "Create realistic fake WhatsApp chats and download PNGs that match the preview exactly. Free, no signup."
 };
 
 export default function RootLayout({ children }: { children: React.ReactNode }) {

--- a/app/page.tsx
+++ b/app/page.tsx
@@ -26,25 +26,15 @@ export default function Page() {
   const [state, setState] = useState<ChatState>(defaultState);
 
   const liveRef = useRef<HTMLDivElement>(null);
-  const exportRef = useRef<HTMLDivElement>(null);
 
   const formSetState = (updater: (s: ChatState) => ChatState) =>
     setState((s) => updater(s));
 
   async function handleDownload() {
-    const node = exportRef.current;
+    const node = liveRef.current;
     if (!node) return;
 
-    const prevDisplay = node.style.display;
-    const prevOpacity = node.style.opacity;
-    node.style.display = "block";
-    node.style.opacity = "1";
-    await new Promise((r) => setTimeout(r, 50));
-
     const blob = await exportNodeToPNG(node, 2);
-
-    node.style.display = prevDisplay;
-    node.style.opacity = prevOpacity;
 
     const url = URL.createObjectURL(blob);
     const a = document.createElement("a");
@@ -68,22 +58,6 @@ export default function Page() {
         </button>
       </div>
 
-      {/* Hidden export surface (full size, no glass) */}
-      <div
-        ref={exportRef}
-        style={{
-          width: 390,
-          height: 760,
-          position: "fixed",
-          left: "-10000px",
-          top: "0",
-          opacity: 0,
-          pointerEvents: "none",
-          display: "none",
-        }}
-      >
-        <ChatPreview state={state} previewRef={{ current: null }} frame="none" exportSize={{ w: 390, h: 760 }} />
-      </div>
     </div>
   );
 }


### PR DESCRIPTION
## Summary
- export on-screen preview to PNG so downloads match live view
- clean up unused off-screen export surface
- expand site description for SEO

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68a6538960dc8329b75c998eeda44481