### PR TITLE
Rebrand and restyle to PretendChat

### DIFF
--- a/app/layout.tsx
+++ b/app/layout.tsx
@@ -1,8 +1,24 @@
 import './globals.css';
 
 export const metadata = {
-  title: "Fake WhatsApp Chat Generator",
-  description: "Create realistic fake WhatsApp chats and download PNGs that match the preview exactly. Free, no signup."
+  title: 'PretendChat | WhatsApp Chat Generator',
+  description:
+    'Design realistic WhatsApp conversations with PretendChat and download pixel-perfect images. Free tool, no signup.',
+  keywords: [
+    'PretendChat',
+    'WhatsApp chat generator',
+    'fake WhatsApp messages',
+    'WhatsApp fake chat creator',
+  ],
+  metadataBase: new URL('https://pretendchat.com'),
+  openGraph: {
+    title: 'PretendChat | WhatsApp Chat Generator',
+    description:
+      'Create and export realistic WhatsApp chats instantly with PretendChat.',
+    url: 'https://pretendchat.com',
+    siteName: 'PretendChat',
+    type: 'website',
+  },
 };
 
 export default function RootLayout({ children }: { children: React.ReactNode }) {
@@ -14,3 +30,4 @@ export default function RootLayout({ children }: { children: React.ReactNode }) 
     </html>
   );
 }
+

--- a/app/page.tsx
+++ b/app/page.tsx
@@ -1,9 +1,9 @@
 "use client";
-import { useRef, useState } from "react";
-import ChatForm from "@/components/ChatForm";
-import ChatPreview from "@/components/ChatPreview";
-import { ChatState } from "@/src/lib/types";
-import { exportNodeToPNG } from "@/src/lib/exportToPng";
+import { useRef, useState } from 'react';
+import ChatForm from '@/components/ChatForm';
+import ChatPreview from '@/components/ChatPreview';
+import { ChatState } from '@/src/lib/types';
+import { exportNodeToPNG } from '@/src/lib/exportToPng';
 
 const defaultState: ChatState = {
   header: {
@@ -39,7 +39,7 @@ export default function Page() {
     const url = URL.createObjectURL(blob);
     const a = document.createElement("a");
     a.href = url;
-    a.download = "fake-whatsapp-chat.png";
+    a.download = 'pretendchat-whatsapp-chat.png';
     document.body.appendChild(a);
     a.click();
     a.remove();
@@ -47,17 +47,28 @@ export default function Page() {
   }
 
   return (
-    <div className="grid md:grid-cols-[1fr_auto] gap-6">
-      <ChatForm state={state} setState={formSetState} />
-
-      <div>
-        {/* Smaller on-screen preview */}
-        <ChatPreview state={state} previewRef={liveRef} frame="glass" exportSize={{ w: 320, h: 693 }} />
-        <button className="btn mt-4" onClick={handleDownload}>
-          Download Image
-        </button>
+    <main className="max-w-5xl mx-auto p-4">
+      <h1 className="mb-6 text-3xl font-bold text-center text-[#00A884]">
+        PretendChat
+      </h1>
+      <div className="grid md:grid-cols-[1fr_auto] gap-6">
+        <ChatForm state={state} setState={formSetState} />
+        <div className="flex flex-col items-center">
+          {/* Smaller on-screen preview */}
+          <ChatPreview
+            state={state}
+            previewRef={liveRef}
+            frame="glass"
+            exportSize={{ w: 320, h: 693 }}
+          />
+          <button
+            className="mt-4 rounded-md bg-[#00A884] px-4 py-2 text-sm font-medium text-white hover:bg-[#029e70]"
+            onClick={handleDownload}
+          >
+            Download Image
+          </button>
+        </div>
       </div>
-
-    </div>
+    </main>
   );
 }

--- a/components/ChatForm.tsx
+++ b/components/ChatForm.tsx
@@ -17,6 +17,8 @@ export default function ChatForm({
   setState: (updater: (s: ChatState) => ChatState) => void;
 }) {
   const id = useId();
+  const inputCls =
+    'w-full rounded-md border border-neutral-300 px-3 py-2 text-sm focus:outline-none focus:border-[#00A884] focus:ring-1 focus:ring-[#00A884]/50';
   function setHeader<K extends keyof ChatState['header']>(key: K, val: ChatState['header'][K]) {
     setState(s => ({ ...s, header: { ...s.header, [key]: val } }));
   }
@@ -39,20 +41,25 @@ export default function ChatForm({
   }
 
   return (
-    <div className="space-y-6">
+    <div className="space-y-6 rounded-lg bg-white p-6 shadow-sm">
       <section className="space-y-3">
         <div className="text-sm font-semibold">Phone & Contact</div>
         <FieldRow>
           <div>
             <L>Contact name</L>
-            <input className="w-full border rounded px-2 py-1.5" value={state.header.contactName}
-                   onChange={e => setHeader('contactName', e.target.value.slice(0, 40))} />
+            <input
+              className={inputCls}
+              value={state.header.contactName}
+              onChange={e => setHeader('contactName', e.target.value.slice(0, 40))}
+            />
           </div>
           <div>
             <L>Online mode</L>
-            <select className="w-full border rounded px-2 py-1.5"
-                    value={state.header.onlineMode}
-                    onChange={e => setHeader('onlineMode', e.target.value as OnlineMode)}>
+            <select
+              className={inputCls}
+              value={state.header.onlineMode}
+              onChange={e => setHeader('onlineMode', e.target.value as OnlineMode)}
+            >
               <option value="online">online</option>
               <option value="typing…">typing…</option>
               <option value="last seen">last seen</option>
@@ -63,23 +70,31 @@ export default function ChatForm({
         {state.header.onlineMode === 'last seen' && (
           <div>
             <L>Last seen text</L>
-            <input className="w-full border rounded px-2 py-1.5" placeholder="today at 09:30"
-                   value={state.header.lastSeenText}
-                   onChange={e => setHeader('lastSeenText', e.target.value.slice(0, 40))} />
+            <input
+              className={inputCls}
+              placeholder="today at 09:30"
+              value={state.header.lastSeenText}
+              onChange={e => setHeader('lastSeenText', e.target.value.slice(0, 40))}
+            />
           </div>
         )}
 
         <FieldRow>
           <div>
             <L>Carrier</L>
-            <input className="w-full border rounded px-2 py-1.5" value={state.header.carrier}
-                   onChange={e => setHeader('carrier', e.target.value.slice(0, 16))} />
+            <input
+              className={inputCls}
+              value={state.header.carrier}
+              onChange={e => setHeader('carrier', e.target.value.slice(0, 16))}
+            />
           </div>
           <div>
             <L>Connection</L>
-            <select className="w-full border rounded px-2 py-1.5"
-                    value={state.header.connection}
-                    onChange={e => setHeader('connection', e.target.value as ConnectionType)}>
+            <select
+              className={inputCls}
+              value={state.header.connection}
+              onChange={e => setHeader('connection', e.target.value as ConnectionType)}
+            >
               <option>Wi-Fi</option>
               <option>4G</option>
               <option>5G</option>
@@ -90,15 +105,23 @@ export default function ChatForm({
         <FieldRow>
           <div>
             <L>Clock time</L>
-            <input className="w-full border rounded px-2 py-1.5" value={state.header.phoneTime}
-                   onChange={e => setHeader('phoneTime', e.target.value.slice(0, 12))} />
+            <input
+              className={inputCls}
+              value={state.header.phoneTime}
+              onChange={e => setHeader('phoneTime', e.target.value.slice(0, 12))}
+            />
           </div>
           <div className="grid grid-cols-2 gap-3">
             <div>
               <L>Battery %</L>
-              <input type="number" className="w-full border rounded px-2 py-1.5"
-                     value={state.header.batteryPercent}
-                     onChange={e => setHeader('batteryPercent', Math.max(0, Math.min(100, Number(e.target.value))))} />
+              <input
+                type="number"
+                className={inputCls}
+                value={state.header.batteryPercent}
+                onChange={e =>
+                  setHeader('batteryPercent', Math.max(0, Math.min(100, Number(e.target.value))))
+                }
+              />
             </div>
             <div className="flex items-end gap-2">
               <input id={`${id}-chg`} type="checkbox"
@@ -111,21 +134,34 @@ export default function ChatForm({
 
         <div>
           <L>Avatar image</L>
-          <input type="file" accept="image/*"
-                 onChange={async e => {
-                   const f = e.target.files?.[0];
-                   if (!f) return;
-                   const data = await fileToDataUrl(f);
-                   setHeader('avatarDataUrl', data);
-                 }} />
+          <input
+            type="file"
+            accept="image/*"
+            className="block w-full text-sm text-neutral-500 file:mr-4 file:cursor-pointer file:rounded-md file:border-0 file:bg-[#00A884] file:px-3 file:py-2 file:text-white hover:file:bg-[#029e70]"
+            onChange={async e => {
+              const f = e.target.files?.[0];
+              if (!f) return;
+              const data = await fileToDataUrl(f);
+              setHeader('avatarDataUrl', data);
+            }}
+          />
+          {state.header.avatarDataUrl && (
+            <img
+              src={state.header.avatarDataUrl}
+              alt="avatar preview"
+              className="mt-2 h-16 w-16 rounded-full object-cover"
+            />
+          )}
         </div>
 
         <div className="grid grid-cols-2 gap-3">
           <div>
             <L>Wallpaper</L>
-            <select className="w-full border rounded px-2 py-1.5"
-                    value={state.header.wallpaper}
-                    onChange={e => setHeader('wallpaper', e.target.value as any)}>
+            <select
+              className={inputCls}
+              value={state.header.wallpaper}
+              onChange={e => setHeader('wallpaper', e.target.value as any)}
+            >
               <option value="solid">Solid</option>
               <option value="paper">Paper pattern</option>
             </select>
@@ -142,7 +178,10 @@ export default function ChatForm({
       <section className="space-y-3">
         <div className="flex items-center justify-between">
           <div className="text-sm font-semibold">Messages</div>
-          <button onClick={addMessage} className="text-sm text-white bg-black rounded px-3 py-1.5">
+          <button
+            onClick={addMessage}
+            className="rounded-md bg-[#00A884] px-3 py-1.5 text-sm font-medium text-white hover:bg-[#029e70]"
+          >
             + Add message
           </button>
         </div>
@@ -153,18 +192,22 @@ export default function ChatForm({
               <div className="grid grid-cols-2 gap-3">
                 <div>
                   <L>Sender</L>
-                  <select className="w-full border rounded px-2 py-1.5"
-                          value={m.sender}
-                          onChange={e => updateMessage(m.id, { sender: e.target.value as Sender })}>
+                  <select
+                    className={inputCls}
+                    value={m.sender}
+                    onChange={e => updateMessage(m.id, { sender: e.target.value as Sender })}
+                  >
                     <option value="me">Me</option>
                     <option value="them">Them</option>
                   </select>
                 </div>
                 <div>
                   <L>Kind</L>
-                  <select className="w-full border rounded px-2 py-1.5"
-                          value={m.kind}
-                          onChange={e => updateMessage(m.id, { kind: e.target.value as MsgKind })}>
+                  <select
+                    className={inputCls}
+                    value={m.kind}
+                    onChange={e => updateMessage(m.id, { kind: e.target.value as MsgKind })}
+                  >
                     <option value="text">Text</option>
                     <option value="image">Image</option>
                   </select>
@@ -174,37 +217,49 @@ export default function ChatForm({
               {m.kind === 'text' && (
                 <div className="mt-2">
                   <L>Text</L>
-                  <textarea rows={3} className="w-full border rounded px-2 py-1.5"
-                            value={m.text ?? ''}
-                            onChange={e => updateMessage(m.id, { text: e.target.value.slice(0, 2000) })} />
+                  <textarea
+                    rows={3}
+                    className={`${inputCls} resize-none`}
+                    value={m.text ?? ''}
+                    onChange={e => updateMessage(m.id, { text: e.target.value.slice(0, 2000) })}
+                  />
                 </div>
               )}
 
               {m.kind === 'image' && (
                 <div className="mt-2">
                   <L>Image upload</L>
-                  <input type="file" accept="image/*"
-                         onChange={async e => {
-                           const f = e.target.files?.[0];
-                           if (!f) return;
-                           const data = await fileToDataUrl(f);
-                           updateMessage(m.id, { imageDataUrl: data });
-                         }} />
+                  <input
+                    type="file"
+                    accept="image/*"
+                    className="block w-full text-sm text-neutral-500 file:mr-4 file:cursor-pointer file:rounded-md file:border-0 file:bg-[#00A884] file:px-3 file:py-2 file:text-white hover:file:bg-[#029e70]"
+                    onChange={async e => {
+                      const f = e.target.files?.[0];
+                      if (!f) return;
+                      const data = await fileToDataUrl(f);
+                      updateMessage(m.id, { imageDataUrl: data });
+                    }}
+                  />
                 </div>
               )}
 
               <div className="grid grid-cols-3 gap-3 mt-2">
                 <div>
                   <L>Timestamp</L>
-                  <input className="w-full border rounded px-2 py-1.5" value={m.timestamp}
-                         onChange={e => updateMessage(m.id, { timestamp: e.target.value.slice(0, 8) })} />
+                  <input
+                    className={inputCls}
+                    value={m.timestamp}
+                    onChange={e => updateMessage(m.id, { timestamp: e.target.value.slice(0, 8) })}
+                  />
                 </div>
 
                 <div>
                   <L>Status (me)</L>
-                  <select className="w-full border rounded px-2 py-1.5"
-                          value={m.status}
-                          onChange={e => updateMessage(m.id, { status: e.target.value as MsgStatus })}>
+                  <select
+                    className={inputCls}
+                    value={m.status}
+                    onChange={e => updateMessage(m.id, { status: e.target.value as MsgStatus })}
+                  >
                     <option value="none">none</option>
                     <option value="sent">sent ✓</option>
                     <option value="delivered">delivered ✓✓</option>

--- a/components/ChatPreview.tsx
+++ b/components/ChatPreview.tsx
@@ -182,7 +182,7 @@ export default function ChatPreview({
       </div>
       {showWatermark && (
         <div className="absolute bottom-14 right-3 z-[1] text-[11px] text-neutral-500 select-none">
-          made with FakeChat
+          made with PretendChat.com
         </div>
       )}
     </div>

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,11 +1,11 @@
 {
-  "name": "fake-chat",
+  "name": "pretendchat",
   "version": "1.0.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
-      "name": "fake-chat",
+      "name": "pretendchat",
       "version": "1.0.0",
       "dependencies": {
         "classnames": "^2.5.1",

--- a/package.json
+++ b/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "fake-chat",
+  "name": "pretendchat",
   "private": true,
   "version": "1.0.0",
   "scripts": {


### PR DESCRIPTION
## Summary
- Rebrand metadata and watermark from FakeChat to PretendChat.com with SEO-friendly Open Graph tags
- Refresh UI with WhatsApp-themed inputs, buttons, and card layout
- Show avatar previews and rename package to `pretendchat`

## Testing
- `npm run build`

------
https://chatgpt.com/codex/tasks/task_e_68a656850e4c83298d81d09d7c1a2872