### PR TITLE
Remove frame and watermark from exported chats

### DIFF
--- a/app/layout.tsx
+++ b/app/layout.tsx
@@ -3,7 +3,7 @@ import './globals.css';
 export const metadata = {
   title: 'PretendChat | WhatsApp Chat Generator',
   description:
-    'Design realistic WhatsApp conversations with PretendChat and download pixel-perfect images. Free tool, no signup.',
+    'Design realistic WhatsApp conversations with PretendChat and download pixel-perfect images without watermark. Free tool, no signup.',
   keywords: [
     'PretendChat',
     'WhatsApp chat generator',
@@ -14,7 +14,7 @@ export const metadata = {
   openGraph: {
     title: 'PretendChat | WhatsApp Chat Generator',
     description:
-      'Create and export realistic WhatsApp chats instantly with PretendChat.',
+      'Create and export realistic WhatsApp chats instantly with PretendChat without watermark.',
     url: 'https://pretendchat.com',
     siteName: 'PretendChat',
     type: 'website',

--- a/app/page.tsx
+++ b/app/page.tsx
@@ -19,12 +19,11 @@ const defaultState: ChatState = {
     avatarDataUrl: null,
   },
   messages: [],
-  showWatermark: true,
 };
 
 export default function Page() {
   const [state, setState] = useState<ChatState>(defaultState);
-
+  const [exporting, setExporting] = useState(false);
   const liveRef = useRef<HTMLDivElement>(null);
 
   const formSetState = (updater: (s: ChatState) => ChatState) =>
@@ -34,7 +33,10 @@ export default function Page() {
     const node = liveRef.current;
     if (!node) return;
 
+    setExporting(true);
+    await new Promise((resolve) => requestAnimationFrame(() => resolve(null)));
     const blob = await exportNodeToPNG(node, 2);
+    setExporting(false);
 
     const url = URL.createObjectURL(blob);
     const a = document.createElement("a");
@@ -58,7 +60,7 @@ export default function Page() {
           <ChatPreview
             state={state}
             previewRef={liveRef}
-            frame="glass"
+            frame={exporting ? 'none' : 'glass'}
             exportSize={{ w: 320, h: 693 }}
           />
           <button

--- a/components/ChatForm.tsx
+++ b/components/ChatForm.tsx
@@ -154,24 +154,16 @@ export default function ChatForm({
           )}
         </div>
 
-        <div className="grid grid-cols-2 gap-3">
-          <div>
-            <L>Wallpaper</L>
-            <select
-              className={inputCls}
-              value={state.header.wallpaper}
-              onChange={e => setHeader('wallpaper', e.target.value as any)}
-            >
-              <option value="solid">Solid</option>
-              <option value="paper">Paper pattern</option>
-            </select>
-          </div>
-          <div className="flex items-end gap-2">
-            <input id={`${id}-wm`} type="checkbox"
-                   checked={state.showWatermark}
-                   onChange={e => setState(s => ({ ...s, showWatermark: e.target.checked }))} />
-            <label htmlFor={`${id}-wm`} className="text-[13px]">Show watermark</label>
-          </div>
+        <div>
+          <L>Wallpaper</L>
+          <select
+            className={inputCls}
+            value={state.header.wallpaper}
+            onChange={e => setHeader('wallpaper', e.target.value as any)}
+          >
+            <option value="solid">Solid</option>
+            <option value="paper">Paper pattern</option>
+          </select>
         </div>
       </section>
 

--- a/components/ChatPreview.tsx
+++ b/components/ChatPreview.tsx
@@ -17,7 +17,7 @@ function StatusBar({ time, carrier, connection, battery, charging }:{
         <span>{connection}</span>
         <div className="flex items-center gap-1">
           <div className="w-5 h-2.5 border border-black/70 rounded-[3px] relative">
-            <div className="absolute right-[-4px] top-0.5 w-1 h-1.5 bg-black/70 rounded-sm" />
+            <div className="absolute right-[-4px] top-1/2 -translate-y-1/2 w-1 h-1.5 bg-black/70 rounded-sm" />
             <div className="h-full bg-black/80" style={{width:`${Math.max(0,Math.min(100,battery))}%`}} />
           </div>
           {charging && <span title="charging">⚡</span>}
@@ -32,7 +32,17 @@ function NavBarIOS({ name, subtitle, avatar }:{
   return (
     <div className="h-12 px-2 flex items-center justify-between bg-[#F2F3F5] border-b border-black/10">
       <div className="flex items-center gap-1 text-[16px] text-[#007AFF] font-medium">
-        <svg viewBox="0 0 24 24" className="w-5 h-5"><path fill="currentColor" d="M15.41 7.41 14 6l-6 6 6 6 1.41-1.41L10.83 12z"/></svg>
+        <svg
+          viewBox="0 0 24 24"
+          className="w-5 h-5"
+          fill="none"
+          stroke="currentColor"
+          strokeWidth={2}
+          strokeLinecap="round"
+          strokeLinejoin="round"
+        >
+          <polyline points="15 18 9 12 15 6" />
+        </svg>
         <span>Chats</span>
       </div>
       <div className="absolute left-1/2 -translate-x-1/2 text-center leading-tight">
@@ -101,7 +111,7 @@ export default function ChatPreview({
       contactName, onlineMode, lastSeenText, phoneTime, carrier,
       connection, batteryPercent, charging, avatarDataUrl, wallpaper
     },
-    messages, showWatermark
+    messages
   } = state;
 
   const subtitle =
@@ -140,7 +150,7 @@ export default function ChatPreview({
         </div>
       </div>
       {/* input */}
-      <div className="absolute left-0 right-0 bottom-0 z-[1] flex items-center gap-2 px-3 pb-3">
+      <div className="absolute left-0 right-0 bottom-0 z-[1] flex items-center gap-2 px-3 py-3 bg-white border-t border-neutral-200">
         <div
           className="w-10 h-10 rounded-full border border-wpTickBlue bg-white flex items-center justify-center text-wpTickBlue"
           aria-label="add attachment"
@@ -180,11 +190,6 @@ export default function ChatPreview({
           </svg>
         </div>
       </div>
-      {showWatermark && (
-        <div className="absolute bottom-14 right-3 z-[1] text-[11px] text-neutral-500 select-none">
-          made with PretendChat.com
-        </div>
-      )}
     </div>
   );
 

--- a/src/lib/types.ts
+++ b/src/lib/types.ts
@@ -30,5 +30,4 @@ export interface ChatMessage {
 export interface ChatState {
   header: HeaderState;
   messages: ChatMessage[];
-  showWatermark: boolean;
 }


### PR DESCRIPTION
## Summary
- export chat screenshots without phone frame or watermark
- center status icons and clean up chat input bar styling
- mention "without watermark" in SEO metadata

## Testing
- `npm run build`

------
https://chatgpt.com/codex/tasks/task_e_68a658c1e9b48329918ea0c03a2823fe