### PR TITLE
Fix export misalignment and include device frame

### DIFF
--- a/app/page.tsx
+++ b/app/page.tsx
@@ -23,7 +23,6 @@ const defaultState: ChatState = {
 
 export default function Page() {
   const [state, setState] = useState<ChatState>(defaultState);
-  const [exporting, setExporting] = useState(false);
   const liveRef = useRef<HTMLDivElement>(null);
 
   const formSetState = (updater: (s: ChatState) => ChatState) =>
@@ -33,10 +32,8 @@ export default function Page() {
     const node = liveRef.current;
     if (!node) return;
 
-    setExporting(true);
     await new Promise((resolve) => requestAnimationFrame(() => resolve(null)));
     const blob = await exportNodeToPNG(node, 2);
-    setExporting(false);
 
     const url = URL.createObjectURL(blob);
     const a = document.createElement("a");
@@ -60,7 +57,6 @@ export default function Page() {
           <ChatPreview
             state={state}
             previewRef={liveRef}
-            frame={exporting ? 'none' : 'glass'}
             exportSize={{ w: 320, h: 693 }}
           />
           <button

--- a/src/lib/exportToPng.ts
+++ b/src/lib/exportToPng.ts
@@ -6,6 +6,9 @@ export async function exportNodeToPNG(node: HTMLElement, scale = 2): Promise<Blo
     scale,
     useCORS: true,
     allowTaint: true,
+    // Ensure the captured output isn't offset when the page is scrolled
+    scrollX: 0,
+    scrollY: -window.scrollY,
   });
 
   const blob = await new Promise<Blob | null>((resolve) =>


### PR DESCRIPTION
## Summary
- Export screenshot directly from the live preview so the downloaded image matches the on-screen frame
- Prevent scroll offset during export to keep header elements aligned

## Testing
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68a65b1a6aa88329a297d63736078dcf