### PR TITLE
Align status bar and remove frame from exports

### DIFF
--- a/app/page.tsx
+++ b/app/page.tsx
@@ -23,13 +23,14 @@ const defaultState: ChatState = {
 
 export default function Page() {
   const [state, setState] = useState<ChatState>(defaultState);
-  const liveRef = useRef<HTMLDivElement>(null);
+  const previewRef = useRef<HTMLDivElement>(null);
+  const exportRef = useRef<HTMLDivElement>(null);
 
   const formSetState = (updater: (s: ChatState) => ChatState) =>
     setState((s) => updater(s));
 
   async function handleDownload() {
-    const node = liveRef.current;
+    const node = exportRef.current;
     if (!node) return;
 
     await new Promise((resolve) => requestAnimationFrame(() => resolve(null)));
@@ -56,9 +57,18 @@ export default function Page() {
           {/* Smaller on-screen preview */}
           <ChatPreview
             state={state}
-            previewRef={liveRef}
+            previewRef={previewRef}
             exportSize={{ w: 320, h: 693 }}
           />
+          {/* Off-screen export surface without frame */}
+          <div className="fixed -top-[10000px]" aria-hidden>
+            <ChatPreview
+              state={state}
+              previewRef={exportRef}
+              frame="none"
+              exportSize={{ w: 320, h: 693 }}
+            />
+          </div>
           <button
             className="mt-4 rounded-md bg-[#00A884] px-4 py-2 text-sm font-medium text-white hover:bg-[#029e70]"
             onClick={handleDownload}

--- a/components/ChatPreview.tsx
+++ b/components/ChatPreview.tsx
@@ -10,13 +10,13 @@ function StatusBar({ time, carrier, connection, battery, charging }:{
   time:string; carrier:string; connection:string; battery:number; charging:boolean;
 }) {
   return (
-    <div className="h-7 px-3 pt-[2px] flex items-center justify-between text-[12px] text-black/80 bg-[#F2F3F5]">
-      <span className="tracking-tight">{time}</span>
-      <div className="flex items-center gap-2">
-        <span className="uppercase">{carrier}</span>
-        <span>{connection}</span>
-        <div className="flex items-center gap-1">
-          <div className="w-5 h-2.5 border border-black/70 rounded-[3px] relative">
+    <div className="h-7 px-2 flex items-center justify-between text-[12px] text-black/80 bg-[#F2F3F5]">
+      <span className="tracking-tight leading-none">{time}</span>
+      <div className="flex items-center gap-2 leading-none">
+        <span className="uppercase leading-none">{carrier}</span>
+        <span className="leading-none">{connection}</span>
+        <div className="flex items-center gap-1 leading-none">
+          <div className="w-5 h-2.5 border border-black/70 rounded-[3px] relative flex items-center">
             <div className="absolute right-[-4px] top-1/2 -translate-y-1/2 w-1 h-1.5 bg-black/70 rounded-sm" />
             <div className="h-full bg-black/80" style={{width:`${Math.max(0,Math.min(100,battery))}%`}} />
           </div>


### PR DESCRIPTION
## Summary
- align WhatsApp status bar elements
- export chat images without phone frame by rendering off-screen version

## Testing
- `npm test` *(fails: Missing script: "test")*
- `npx tsc --noEmit`


------
https://chatgpt.com/codex/tasks/task_e_68a65d39a3ec832985848130f8a8adcf