### PR TITLE
Fix top bar alignment and enable scrollable chat preview

### DIFF
--- a/app/page.tsx
+++ b/app/page.tsx
@@ -31,7 +31,14 @@ export default function Page() {
 
   async function handleDownload() {
     const node = exportRef.current;
-    if (!node) return;
+    const previewNode = previewRef.current;
+    if (!node || !previewNode) return;
+
+    const src = previewNode.querySelector('[data-scrollable]') as HTMLElement | null;
+    const dst = node.querySelector('[data-scrollable]') as HTMLElement | null;
+    if (src && dst) {
+      dst.scrollTop = src.scrollTop;
+    }
 
     await new Promise((resolve) => requestAnimationFrame(() => resolve(null)));
     const blob = await exportNodeToPNG(node, 2);

--- a/components/ChatPreview.tsx
+++ b/components/ChatPreview.tsx
@@ -10,9 +10,8 @@ function StatusBar({ time, carrier, connection, battery, charging }:{
   time:string; carrier:string; connection:string; battery:number; charging:boolean;
 }) {
   return (
-    <div className="h-7 px-2 flex items-center justify-between text-[12px] text-black/80 bg-[#F2F3F5]">
-      <span className="tracking-tight leading-none">{time}</span>
-      <div className="flex items-center gap-2 leading-none">
+    <div className="relative h-7 bg-[#F2F3F5] text-[12px] text-black/80">
+      <div className="absolute right-2 top-1/2 -translate-y-1/2 flex items-center gap-2 leading-none">
         <span className="uppercase leading-none">{carrier}</span>
         <span className="leading-none">{connection}</span>
         <div className="flex items-center gap-1 leading-none">
@@ -22,6 +21,9 @@ function StatusBar({ time, carrier, connection, battery, charging }:{
           </div>
           {charging && <span title="charging">⚡</span>}
         </div>
+      </div>
+      <div className="flex h-full items-center justify-center tracking-tight leading-none">
+        {time}
       </div>
     </div>
   );
@@ -144,7 +146,10 @@ export default function ChatPreview({
         <NavBarIOS name={contactName} subtitle={subtitle} avatar={avatarDataUrl} />
       </div>
       {/* messages */}
-      <div className="relative z-[1] flex-1 overflow-hidden px-3 pt-3 pb-16">
+      <div
+        className="relative z-[1] flex-1 overflow-y-auto px-3 pt-3 pb-16"
+        data-scrollable
+      >
         <div className="flex flex-col gap-[6px]">
           {messages.map((m) => <Bubble key={m.id} m={m} />)}
         </div>


### PR DESCRIPTION
## Summary
- center time and align network indicators in status bar
- allow scrolling in chat preview and export current view

## Testing
- `npm test` *(fails: Missing script)*
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68a65f29914483299b68a74fc711768e