### PR TITLE
Fix status bar alignment and crop exports to visible chat

### DIFF
--- a/components/ChatPreview.tsx
+++ b/components/ChatPreview.tsx
@@ -11,7 +11,7 @@ function StatusBar({ time, carrier, connection, battery, charging }:{
 }) {
   return (
     <div className="relative h-7 bg-[#F2F3F5] text-[12px] text-black/80">
-      <div className="absolute right-2 top-1/2 -translate-y-1/2 flex items-center gap-2 leading-none">
+      <div className="absolute inset-y-0 right-2 flex items-center gap-2 leading-none">
         <span className="uppercase leading-none">{carrier}</span>
         <span className="leading-none">{connection}</span>
         <div className="flex items-center gap-1 leading-none">

--- a/src/lib/exportToPng.ts
+++ b/src/lib/exportToPng.ts
@@ -1,6 +1,13 @@
 import html2canvas from "html2canvas";
 
 export async function exportNodeToPNG(node: HTMLElement, scale = 2): Promise<Blob> {
+  // Preserve scroll positions of any nested scrollable regions so the export
+  // matches what the user sees on screen.
+  const scrollables = Array.from(
+    node.querySelectorAll<HTMLElement>("[data-scrollable]")
+  );
+  const positions = scrollables.map((el) => el.scrollTop);
+
   const canvas = await html2canvas(node, {
     backgroundColor: null,
     scale,
@@ -9,15 +16,42 @@ export async function exportNodeToPNG(node: HTMLElement, scale = 2): Promise<Blo
     // Ensure the captured output isn't offset when the page is scrolled
     scrollX: 0,
     scrollY: -window.scrollY,
+    onclone: (doc) => {
+      const cloned = doc.querySelectorAll<HTMLElement>("[data-scrollable]");
+      cloned.forEach((el, i) => {
+        el.scrollTop = positions[i] ?? 0;
+      });
+    },
   });
 
+  // html2canvas renders all scrollable content. Crop the result to the
+  // element's on-screen size so only visible messages are exported.
+  const { width, height } = node.getBoundingClientRect();
+  const output = document.createElement("canvas");
+  output.width = width * scale;
+  output.height = height * scale;
+  const ctx = output.getContext("2d");
+  if (ctx) {
+    ctx.drawImage(
+      canvas,
+      0,
+      0,
+      output.width,
+      output.height,
+      0,
+      0,
+      output.width,
+      output.height
+    );
+  }
+
   const blob = await new Promise<Blob | null>((resolve) =>
-    canvas.toBlob((b) => resolve(b), "image/png")
+    output.toBlob((b) => resolve(b), "image/png")
   );
 
   if (blob) return blob;
 
-  const dataUrl = canvas.toDataURL("image/png");
+  const dataUrl = output.toDataURL("image/png");
   const res = await fetch(dataUrl);
   return res.blob();
 }


### PR DESCRIPTION
## Summary
- keep status bar icons vertically aligned without transforms
- preserve scroll position and crop PNG exports so only the visible chat area is captured

## Testing
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68a6618af8008329bae93087c2eb4646