### PR TITLE
Fix status bar time and crop exports to visible chat

### DIFF
--- a/components/ChatPreview.tsx
+++ b/components/ChatPreview.tsx
@@ -11,7 +11,7 @@ function StatusBar({ time, carrier, connection, battery, charging }:{
 }) {
   return (
     <div className="relative h-7 bg-[#F2F3F5] text-[12px] text-black/80">
-      <div className="absolute right-2 top-1/2 -translate-y-1/2 flex items-center gap-2 leading-none">
+      <div className="absolute inset-y-0 right-2 flex items-center gap-2 leading-none">
         <span className="uppercase leading-none">{carrier}</span>
         <span className="leading-none">{connection}</span>
         <div className="flex items-center gap-1 leading-none">
@@ -22,7 +22,7 @@ function StatusBar({ time, carrier, connection, battery, charging }:{
           {charging && <span title="charging">⚡</span>}
         </div>
       </div>
-      <div className="flex h-full items-center justify-center tracking-tight leading-none">
+      <div className="absolute left-1/2 top-1/2 -translate-x-1/2 -translate-y-1/2 leading-none font-semibold">
         {time}
       </div>
     </div>

--- a/src/lib/exportToPng.ts
+++ b/src/lib/exportToPng.ts
@@ -1,6 +1,13 @@
 import html2canvas from "html2canvas";
 
 export async function exportNodeToPNG(node: HTMLElement, scale = 2): Promise<Blob> {
+  // Preserve scroll positions of any nested scrollable regions so the export
+  // matches what the user sees on screen.
+  const scrollables = Array.from(
+    node.querySelectorAll<HTMLElement>("[data-scrollable]")
+  );
+  const positions = scrollables.map((el) => el.scrollTop);
+
   const canvas = await html2canvas(node, {
     backgroundColor: null,
     scale,
@@ -9,8 +16,19 @@ export async function exportNodeToPNG(node: HTMLElement, scale = 2): Promise<Blo
     // Ensure the captured output isn't offset when the page is scrolled
     scrollX: 0,
     scrollY: -window.scrollY,
+    onclone: (doc) => {
+      const cloned = doc.querySelectorAll<HTMLElement>("[data-scrollable]");
+      cloned.forEach((el, i) => {
+        const top = positions[i] ?? 0;
+        el.scrollTop = 0;
+        el.style.overflow = "hidden";
+        const inner = el.firstElementChild as HTMLElement | null;
+        if (inner) {
+          inner.style.transform = `translateY(-${top}px)`;
+        }
+      });
+    },
   });
-
   const blob = await new Promise<Blob | null>((resolve) =>
     canvas.toBlob((b) => resolve(b), "image/png")
   );


### PR DESCRIPTION
## Summary
- center time and keep status icons aligned without overlap
- hide overflow and shift scrollable content so exported PNG matches on-screen chat

## Testing
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68a6618af8008329bae93087c2eb4646