### PR TITLE
Fix status bar time and crop exports to visible chat

### DIFF
--- a/components/ChatPreview.tsx
+++ b/components/ChatPreview.tsx
@@ -10,20 +10,19 @@ function StatusBar({ time, carrier, connection, battery, charging }:{
   time:string; carrier:string; connection:string; battery:number; charging:boolean;
 }) {
   return (
-    <div className="relative h-7 bg-[#F2F3F5] text-[12px] text-black/80">
-      <div className="absolute right-2 top-1/2 -translate-y-1/2 flex items-center gap-2 leading-none">
-        <span className="uppercase leading-none">{carrier}</span>
-        <span className="leading-none">{connection}</span>
-        <div className="flex items-center gap-1 leading-none">
+    <div className="grid grid-cols-3 items-center h-7 bg-[#F2F3F5] text-[12px] text-black/80">
+      <div />
+      <div className="justify-self-center font-semibold leading-none">{time}</div>
+      <div className="justify-self-end flex items-center gap-2 pr-2 leading-none">
+        <span className="uppercase">{carrier}</span>
+        <span>{connection}</span>
+        <div className="flex items-center gap-1">
           <div className="w-5 h-2.5 border border-black/70 rounded-[3px] relative flex items-center">
             <div className="absolute right-[-4px] top-1/2 -translate-y-1/2 w-1 h-1.5 bg-black/70 rounded-sm" />
-            <div className="h-full bg-black/80" style={{width:`${Math.max(0,Math.min(100,battery))}%`}} />
+            <div className="h-full bg-black/80" style={{ width: `${Math.max(0, Math.min(100, battery))}%` }} />
           </div>
           {charging && <span title="charging">⚡</span>}
         </div>
-      </div>
-      <div className="flex h-full items-center justify-center tracking-tight leading-none">
-        {time}
       </div>
     </div>
   );

--- a/src/lib/exportToPng.ts
+++ b/src/lib/exportToPng.ts
@@ -1,6 +1,13 @@
 import html2canvas from "html2canvas";
 
 export async function exportNodeToPNG(node: HTMLElement, scale = 2): Promise<Blob> {
+  // Preserve scroll positions of any nested scrollable regions so the export
+  // matches what the user sees on screen.
+  const scrollables = Array.from(
+    node.querySelectorAll<HTMLElement>("[data-scrollable]")
+  );
+  const positions = scrollables.map((el) => el.scrollTop);
+
   const canvas = await html2canvas(node, {
     backgroundColor: null,
     scale,
@@ -9,15 +16,45 @@ export async function exportNodeToPNG(node: HTMLElement, scale = 2): Promise<Blo
     // Ensure the captured output isn't offset when the page is scrolled
     scrollX: 0,
     scrollY: -window.scrollY,
+    onclone: (doc) => {
+      const cloned = doc.querySelectorAll<HTMLElement>("[data-scrollable]");
+      cloned.forEach((el, i) => {
+        const top = positions[i] ?? 0;
+        el.scrollTop = 0;
+        el.style.overflow = "hidden";
+        const inner = el.firstElementChild as HTMLElement | null;
+        if (inner) {
+          inner.style.transform = `translateY(-${top}px)`;
+        }
+      });
+    },
   });
+  const { width, height } = node.getBoundingClientRect();
+  const output = document.createElement("canvas");
+  output.width = width * scale;
+  output.height = height * scale;
+  const ctx = output.getContext("2d");
+  if (ctx) {
+    ctx.drawImage(
+      canvas,
+      0,
+      0,
+      output.width,
+      output.height,
+      0,
+      0,
+      output.width,
+      output.height
+    );
+  }
 
   const blob = await new Promise<Blob | null>((resolve) =>
-    canvas.toBlob((b) => resolve(b), "image/png")
+    output.toBlob((b) => resolve(b), "image/png")
   );
 
   if (blob) return blob;
 
-  const dataUrl = canvas.toDataURL("image/png");
+  const dataUrl = output.toDataURL("image/png");
   const res = await fetch(dataUrl);
   return res.blob();
 }


### PR DESCRIPTION
## Summary
- center time and align status icons with CSS grid
- crop html2canvas output to the preview bounds and use defined canvas for PNG export

## Testing
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68a6618af8008329bae93087c2eb4646