### PR TITLE
Screenshot live preview and align status bar

### DIFF
--- a/app/page.tsx
+++ b/app/page.tsx
@@ -24,21 +24,13 @@ const defaultState: ChatState = {
 export default function Page() {
   const [state, setState] = useState<ChatState>(defaultState);
   const previewRef = useRef<HTMLDivElement>(null);
-  const exportRef = useRef<HTMLDivElement>(null);
 
   const formSetState = (updater: (s: ChatState) => ChatState) =>
     setState((s) => updater(s));
 
   async function handleDownload() {
-    const node = exportRef.current;
-    const previewNode = previewRef.current;
-    if (!node || !previewNode) return;
-
-    const src = previewNode.querySelector('[data-scrollable]') as HTMLElement | null;
-    const dst = node.querySelector('[data-scrollable]') as HTMLElement | null;
-    if (src && dst) {
-      dst.scrollTop = src.scrollTop;
-    }
+    const node = previewRef.current;
+    if (!node) return;
 
     await new Promise((resolve) => requestAnimationFrame(() => resolve(null)));
     const blob = await exportNodeToPNG(node, 2);
@@ -61,21 +53,11 @@ export default function Page() {
       <div className="grid md:grid-cols-[1fr_auto] gap-6">
         <ChatForm state={state} setState={formSetState} />
         <div className="flex flex-col items-center">
-          {/* Smaller on-screen preview */}
           <ChatPreview
             state={state}
             previewRef={previewRef}
             exportSize={{ w: 320, h: 693 }}
           />
-          {/* Off-screen export surface without frame */}
-          <div className="fixed -top-[10000px]" aria-hidden>
-            <ChatPreview
-              state={state}
-              previewRef={exportRef}
-              frame="none"
-              exportSize={{ w: 320, h: 693 }}
-            />
-          </div>
           <button
             className="mt-4 rounded-md bg-[#00A884] px-4 py-2 text-sm font-medium text-white hover:bg-[#029e70]"
             onClick={handleDownload}

--- a/components/ChatPreview.tsx
+++ b/components/ChatPreview.tsx
@@ -6,24 +6,32 @@ import cn from 'classnames';
 
 type FrameMode = 'glass' | 'none'; // "glass" = pretty on-screen, "none" = export surface
 
-function StatusBar({ time, carrier, connection, battery, charging }:{
-  time:string; carrier:string; connection:string; battery:number; charging:boolean;
+function StatusBar({ time, carrier, battery, charging }:{
+  time: string;
+  carrier: string;
+  battery: number;
+  charging: boolean;
 }) {
   return (
-    <div className="relative h-7 bg-[#F2F3F5] text-[12px] text-black/80">
-      <div className="absolute right-2 top-1/2 -translate-y-1/2 flex items-center gap-2 leading-none">
-        <span className="uppercase leading-none">{carrier}</span>
-        <span className="leading-none">{connection}</span>
-        <div className="flex items-center gap-1 leading-none">
-          <div className="w-5 h-2.5 border border-black/70 rounded-[3px] relative flex items-center">
-            <div className="absolute right-[-4px] top-1/2 -translate-y-1/2 w-1 h-1.5 bg-black/70 rounded-sm" />
-            <div className="h-full bg-black/80" style={{width:`${Math.max(0,Math.min(100,battery))}%`}} />
-          </div>
-          {charging && <span title="charging">⚡</span>}
+    <div className="grid grid-cols-[1fr_auto_1fr] items-center h-7 bg-[#F2F3F5] text-[12px] text-black/80">
+      <div className="flex items-center gap-2 pl-2 leading-none">
+        <div className="flex gap-[2px]" aria-hidden>
+          {Array.from({ length: 5 }).map((_, i) => (
+            <div key={i} className="w-1 h-1 rounded-full bg-black/80" />
+          ))}
         </div>
+        <span>{carrier}</span>
       </div>
-      <div className="flex h-full items-center justify-center tracking-tight leading-none">
+      <div className="justify-self-center font-semibold leading-none">
         {time}
+      </div>
+      <div className="flex items-center gap-1 justify-self-end pr-2 leading-none">
+        <span>{battery} %</span>
+        <div className="relative w-5 h-2.5 border border-black/70 rounded-[3px] flex items-center">
+          <div className="absolute -right-1 top-1/2 -translate-y-1/2 w-1 h-1.5 bg-black/70 rounded-sm" />
+          <div className="h-full bg-black/80" style={{ width: `${Math.max(0, Math.min(100, battery))}%` }} />
+        </div>
+        {charging && <span title="charging">⚡</span>}
       </div>
     </div>
   );
@@ -111,7 +119,7 @@ export default function ChatPreview({
   const {
     header: {
       contactName, onlineMode, lastSeenText, phoneTime, carrier,
-      connection, batteryPercent, charging, avatarDataUrl, wallpaper
+      batteryPercent, charging, avatarDataUrl, wallpaper
     },
     messages
   } = state;
@@ -139,7 +147,6 @@ export default function ChatPreview({
         <StatusBar
           time={phoneTime}
           carrier={carrier}
-          connection={connection}
           battery={batteryPercent}
           charging={charging}
         />
@@ -202,19 +209,18 @@ export default function ChatPreview({
     // On-screen preview (smaller, framed)
     const width = exportSize.w;
     const height = Math.round((width * 926) / 428);
-    return (
-      <div
-        ref={previewRef as React.RefObject<HTMLDivElement>}
-        style={{
-          width: `${width}px`,
-          height: `${height}px`,
-          ['--phone-w' as any]: `${width}px`,
-        }}
-        className="relative"
-      >
-        <DeviceFrame>{Inner}</DeviceFrame>
-      </div>
-    );
+      return (
+        <div
+          style={{
+            width: `${width}px`,
+            height: `${height}px`,
+            ['--phone-w' as any]: `${width}px`,
+          }}
+          className="relative"
+        >
+          <DeviceFrame screenRef={previewRef}>{Inner}</DeviceFrame>
+        </div>
+      );
   }
 
   // Export surface (exact px size, no frame)

--- a/components/DeviceFrame.tsx
+++ b/components/DeviceFrame.tsx
@@ -4,7 +4,13 @@ import React from "react";
  * Classic phone frame with visible bezel, speaker and home button.
  * Scales with --phone-w.
  */
-export default function DeviceFrame({ children }: { children: React.ReactNode }) {
+export default function DeviceFrame({
+  children,
+  screenRef,
+}: {
+  children: React.ReactNode;
+  screenRef?: React.Ref<HTMLDivElement>;
+}) {
   return (
     <div
       className="relative"
@@ -21,7 +27,10 @@ export default function DeviceFrame({ children }: { children: React.ReactNode })
       {/* home button */}
       <div className="absolute bottom-[28px] left-1/2 -translate-x-1/2 w-[72px] h-[72px] rounded-full border-4 border-neutral-700 z-20" />
       {/* screen */}
-      <div className="absolute top-[80px] bottom-[100px] left-[24px] right-[24px] rounded-[24px] bg-white overflow-hidden z-10">
+      <div
+        ref={screenRef}
+        className="absolute top-[80px] bottom-[100px] left-[24px] right-[24px] rounded-[24px] bg-white overflow-hidden z-10"
+      >
         {children}
       </div>
     </div>

--- a/src/lib/exportToPng.ts
+++ b/src/lib/exportToPng.ts
@@ -1,23 +1,29 @@
 import html2canvas from "html2canvas";
 
-export async function exportNodeToPNG(node: HTMLElement, scale = 2): Promise<Blob> {
-  const canvas = await html2canvas(node, {
+export async function exportNodeToPNG(
+  node: HTMLElement,
+  scale = 2
+): Promise<Blob> {
+  const rect = node.getBoundingClientRect();
+
+  const canvas = await html2canvas(document.body, {
     backgroundColor: null,
     scale,
+    x: rect.left,
+    y: rect.top,
+    width: rect.width,
+    height: rect.height,
+    scrollX: -window.scrollX,
+    scrollY: -window.scrollY,
     useCORS: true,
     allowTaint: true,
-    // Ensure the captured output isn't offset when the page is scrolled
-    scrollX: 0,
-    scrollY: -window.scrollY,
   });
 
-  const blob = await new Promise<Blob | null>((resolve) =>
-    canvas.toBlob((b) => resolve(b), "image/png")
-  );
-
-  if (blob) return blob;
-
-  const dataUrl = canvas.toDataURL("image/png");
-  const res = await fetch(dataUrl);
-  return res.blob();
+  return new Promise<Blob>((resolve, reject) => {
+    canvas.toBlob((blob) => {
+      if (blob) resolve(blob);
+      else reject(new Error("Failed to export canvas"));
+    }, "image/png");
+  });
 }
+


### PR DESCRIPTION
## Summary
- center status bar items with a grid layout
- capture the on-screen preview directly to ensure PNG exports match the visible chat
- expose the phone screen element for precise screenshotting

## Testing
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68a6618af8008329bae93087c2eb4646