### PR TITLE
fix: align status bar icons

### DIFF
--- a/components/ChatPreview.tsx
+++ b/components/ChatPreview.tsx
@@ -13,10 +13,9 @@ function StatusBar({ time, carrier, battery, charging }:{
   charging: boolean;
 }) {
   return (
-    <div className="relative h-7 bg-[#F2F3F5] text-[12px] text-black/80">
+    <div className="h-7 bg-[#F2F3F5] text-[12px] text-black/80 grid grid-cols-3 items-center">
       {/* left items */}
-      <div className="absolute inset-y-0 left-0 flex items-center gap-2 pl-2 leading-none">
-
+      <div className="flex items-center gap-2 pl-2 leading-none">
         <div className="flex gap-[2px]" aria-hidden>
           {Array.from({ length: 5 }).map((_, i) => (
             <div key={i} className="w-1 h-1 rounded-full bg-black/80" />
@@ -26,13 +25,12 @@ function StatusBar({ time, carrier, battery, charging }:{
       </div>
 
       {/* centered time */}
-      <div className="absolute top-1/2 left-1/2 -translate-x-1/2 -translate-y-1/2 font-semibold leading-none">
+      <div className="justify-self-center font-semibold leading-none">
         {time}
       </div>
 
       {/* right items */}
-      <div className="absolute inset-y-0 right-0 flex items-center gap-1 pr-2 leading-none justify-end">
-
+      <div className="flex items-center gap-1 pr-2 leading-none justify-self-end">
         <span>{battery} %</span>
         <div className="relative w-5 h-2.5 border border-black/70 rounded-[3px] flex items-center">
           <div className="absolute -right-1 top-1/2 -translate-y-1/2 w-1 h-1.5 bg-black/70 rounded-sm" />


### PR DESCRIPTION
## Summary
- align status bar icons using grid layout so carrier and battery match centered time

## Testing
- `npm test` *(fails: Missing script "test")*

------
https://chatgpt.com/codex/tasks/task_e_68a67223e7708329836e4be5dd7d27e7