### PR TITLE
fix: stabilize status bar layout in exports

### DIFF
--- a/components/ChatPreview.tsx
+++ b/components/ChatPreview.tsx
@@ -13,10 +13,10 @@ function StatusBar({ time, carrier, battery, charging }:{
   charging: boolean;
 }) {
   return (
-    <div className="h-7 bg-[#F2F3F5] text-[12px] text-black/80 grid grid-cols-3 items-center">
+    <div className="relative h-7 bg-[#F2F3F5] text-[12px] text-black/80 flex items-center">
       {/* left items */}
       <div className="flex items-center gap-2 pl-2 leading-none">
-        <div className="flex gap-[2px]" aria-hidden>
+        <div className="flex items-center gap-[2px] h-3" aria-hidden>
           {Array.from({ length: 5 }).map((_, i) => (
             <div key={i} className="w-1 h-1 rounded-full bg-black/80" />
           ))}
@@ -25,16 +25,18 @@ function StatusBar({ time, carrier, battery, charging }:{
       </div>
 
       {/* centered time */}
-      <div className="justify-self-center font-semibold leading-none">
+      <div className="absolute left-1/2 -translate-x-1/2 font-semibold leading-none">
         {time}
       </div>
 
       {/* right items */}
-      <div className="flex items-center gap-1 pr-2 leading-none justify-self-end">
+      <div className="flex items-center gap-1 pr-2 leading-none ml-auto">
         <span>{battery} %</span>
-        <div className="relative w-5 h-2.5 border border-black/70 rounded-[3px] flex items-center">
-          <div className="absolute -right-1 top-1/2 -translate-y-1/2 w-1 h-1.5 bg-black/70 rounded-sm" />
-          <div className="h-full bg-black/80" style={{ width: `${Math.max(0, Math.min(100, battery))}%` }} />
+        <div className="h-3 flex items-center">
+          <div className="relative w-5 h-2.5 border border-black/70 rounded-[3px] flex items-center">
+            <div className="absolute -right-1 top-1/2 -translate-y-1/2 w-1 h-1.5 bg-black/70 rounded-sm" />
+            <div className="h-full bg-black/80" style={{ width: `${Math.max(0, Math.min(100, battery))}%` }} />
+          </div>
         </div>
         {charging && <span title="charging">⚡</span>}
       </div>


### PR DESCRIPTION
## Summary
- use flex container with absolute-centered time to keep status bar icons aligned in exports

## Testing
- no tests run

------
https://chatgpt.com/codex/tasks/task_e_68a6741dc4c08329adb880031d5e1b2e