### PR TITLE
fix: use dedicated export surface for aligned screenshots

### DIFF
--- a/app/page.tsx
+++ b/app/page.tsx
@@ -24,12 +24,13 @@ const defaultState: ChatState = {
 export default function Page() {
   const [state, setState] = useState<ChatState>(defaultState);
   const previewRef = useRef<HTMLDivElement>(null);
+  const exportRef = useRef<HTMLDivElement>(null);
 
   const formSetState = (updater: (s: ChatState) => ChatState) =>
     setState((s) => updater(s));
 
   async function handleDownload() {
-    const node = previewRef.current;
+    const node = exportRef.current;
     if (!node) return;
 
     await new Promise((resolve) => requestAnimationFrame(() => resolve(null)));
@@ -58,6 +59,12 @@ export default function Page() {
             previewRef={previewRef}
             exportSize={{ w: 320, h: 693 }}
           />
+          <div
+            style={{ position: "absolute", left: "-10000px", top: "-10000px" }}
+            aria-hidden
+          >
+            <ChatPreview state={state} previewRef={exportRef} frame="none" />
+          </div>
           <button
             className="mt-4 rounded-md bg-[#00A884] px-4 py-2 text-sm font-medium text-white hover:bg-[#029e70]"
             onClick={handleDownload}

--- a/components/ChatPreview.tsx
+++ b/components/ChatPreview.tsx
@@ -13,10 +13,10 @@ function StatusBar({ time, carrier, battery, charging }:{
   charging: boolean;
 }) {
   return (
-    <div className="h-7 bg-[#F2F3F5] text-[12px] text-black/80 grid grid-cols-3 items-center">
+    <div className="relative h-7 bg-[#F2F3F5] text-[12px] text-black/80 flex items-center">
       {/* left items */}
       <div className="flex items-center gap-2 pl-2 leading-none">
-        <div className="flex gap-[2px]" aria-hidden>
+        <div className="flex items-center gap-[2px] h-3" aria-hidden>
           {Array.from({ length: 5 }).map((_, i) => (
             <div key={i} className="w-1 h-1 rounded-full bg-black/80" />
           ))}
@@ -25,16 +25,18 @@ function StatusBar({ time, carrier, battery, charging }:{
       </div>
 
       {/* centered time */}
-      <div className="justify-self-center font-semibold leading-none">
+      <div className="absolute left-1/2 -translate-x-1/2 font-semibold leading-none">
         {time}
       </div>
 
       {/* right items */}
-      <div className="flex items-center gap-1 pr-2 leading-none justify-self-end">
+      <div className="flex items-center gap-1 pr-2 leading-none ml-auto">
         <span>{battery} %</span>
-        <div className="relative w-5 h-2.5 border border-black/70 rounded-[3px] flex items-center">
-          <div className="absolute -right-1 top-1/2 -translate-y-1/2 w-1 h-1.5 bg-black/70 rounded-sm" />
-          <div className="h-full bg-black/80" style={{ width: `${Math.max(0, Math.min(100, battery))}%` }} />
+        <div className="h-3 flex items-center">
+          <div className="relative w-5 h-2.5 border border-black/70 rounded-[3px] flex items-center">
+            <div className="absolute -right-1 top-1/2 -translate-y-1/2 w-1 h-1.5 bg-black/70 rounded-sm" />
+            <div className="h-full bg-black/80" style={{ width: `${Math.max(0, Math.min(100, battery))}%` }} />
+          </div>
         </div>
         {charging && <span title="charging">⚡</span>}
       </div>

--- a/src/lib/exportToPng.ts
+++ b/src/lib/exportToPng.ts
@@ -4,38 +4,12 @@ export async function exportNodeToPNG(
   node: HTMLElement,
   scale = 2
 ): Promise<Blob> {
-  const rect = node.getBoundingClientRect();
-
-  const canvas = await html2canvas(document.body, {
+  const canvas = await html2canvas(node, {
     backgroundColor: null,
     scale,
-    x: rect.left,
-    y: rect.top,
-    width: rect.width,
-    height: rect.height,
-    scrollX: -window.scrollX,
-    scrollY: -window.scrollY,
     useCORS: true,
     allowTaint: true,
   });
-  const { width, height } = node.getBoundingClientRect();
-  const output = document.createElement("canvas");
-  output.width = width * scale;
-  output.height = height * scale;
-  const ctx = output.getContext("2d");
-  if (ctx) {
-    ctx.drawImage(
-      canvas,
-      0,
-      0,
-      output.width,
-      output.height,
-      0,
-      0,
-      output.width,
-      output.height
-    );
-  }
 
   return new Promise<Blob>((resolve, reject) => {
     canvas.toBlob((blob) => {


### PR DESCRIPTION
## Summary
- render hidden ChatPreview at full size for exports
- capture the export node directly with html2canvas

## Testing
- no tests run

------
https://chatgpt.com/codex/tasks/task_e_68a6741dc4c08329adb880031d5e1b2e